### PR TITLE
Fix for sm64 romdesc info

### DIFF
--- a/romdesc/sm64_info.xml
+++ b/romdesc/sm64_info.xml
@@ -425,7 +425,7 @@
              ptrto="ABInstrument" arraylenvar="NUM_INST"/>
     </struct>
     <struct name="ABDrumList">
-      <field name="drumlist" datatype="uint32" ispointer="1" isarray="1" meaning="None"
+      <field name="drumlist" datatype="uint32" ispointer="1" isarray="1" meaning="List of Ptrs to Drums"
              ptrto="ABDrum" arraylenvar="NUM_DRUM"/>
     </struct>
     <struct name="ABSFXList"/>


### PR DESCRIPTION
NUM_DRUM did not calculate right when this meaning was not set (./Source/BankFile.cpp:489)