### PR TITLE
Force the compiler language version to prevent errors on C++ features like noexcept and constexpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ add_executable(seq64_console
     "juce/modules/juce_audio_basics/juce_audio_basics.cpp"
     "juce/modules/juce_data_structures/juce_data_structures.cpp"
 )
+if(APPLE)
+    set_target_properties(seq64_console PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED TRUE CXX_EXTENSIONS FALSE)
+endif()
 target_include_directories(seq64_console PRIVATE
     "Source"
     "juce/modules"
@@ -104,6 +107,9 @@ if(SEQ64_BUILD_GUI)
     juce_add_gui_app(seq64_gui PRODUCT_NAME "seq64_gui" COMPANY_NAME "Sauraen")
     juce_generate_juce_header(seq64_gui)
     target_sources(seq64_gui PRIVATE ${SEQ64_SHARED_SOURCES} ${SEQ64_GUI_ONLY_SOURCES})
+    if(APPLE)
+        set_target_properties(seq64_gui PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED TRUE CXX_EXTENSIONS FALSE)
+    endif()
     target_compile_definitions(seq64_gui PRIVATE 
         JUCE_STANDALONE_APPLICATION=1
         JUCE_WEB_BROWSER=0


### PR DESCRIPTION
I tried building the project from source on an M1 Apple device, and faced significant issues. Basically, Xcode was complaining that things like `noexcept` are not valid.

We do need to use GNU extensions to import Apple's weird Objective C code, and we need a higher version of the C++ standard than just C++11, which is exactly what this addresses.