### PR TITLE
Properly update last command's value during CC quantization

### DIFF
--- a/Source/SeqFile.cpp
+++ b/Source/SeqFile.cpp
@@ -1412,7 +1412,7 @@ int SeqFile::importMIDI(File midifile, ValueTree midiopts){
                         //lastcmd will be invalid if this is an action we aren't tracking
                         ValueTree tmpcmd = ccstates[cc]->lastcmd.getChildWithProperty(idCC, cc);
                         if(tmpcmd.isValid()){
-                            tmpcmd.setProperty("Value", value, nullptr);
+                            tmpcmd.setProperty(idValue, value, nullptr);
                         }else{
                             dbgmsg("Internal consistency error in CC quantization!");
                             return 2;


### PR DESCRIPTION
Since MML has less precision in both PPQN and (at least in some cases, such as pitch wheel) the actual CC values themselves, `SeqFile::importMIDI()` quantizes CC messages. When it decides to "quantize out" a MIDI CC message and not create a new MML command for it, it tries to "`Update the last command's value`" instead -- which makes sense, since this ensures that the CC state after that point matches the most recent value from the MIDI data.

Due to a bug, however, the last command's value isn't *actually* updated. The function sets the MML command's `"Value"` property (uppercase), but the actual name of the property is `"value"` (lowercase), so setting `"Value"` has no real effect. This can lead to incorrect CC states in converted MML sequences.

This PR fixes the property name. I used `idValue` instead of `"value"` to match the code that creates new CC MML events (see line 1443).